### PR TITLE
Add blog post editor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 _site/*
 _theme_packages/*
+.jekyll-cache/
 
 Thumbs.db
 .DS_Store

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+theme: minima
+title: "Sylvain Bauza"
+description: "Projects and presentations"

--- a/editor/index.html
+++ b/editor/index.html
@@ -1,0 +1,821 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Blog Post Editor</title>
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg: #0f111a;
+      --surface: #1a1d2e;
+      --surface2: #232640;
+      --border: #2d3154;
+      --text: #e2e4f0;
+      --text-muted: #8b8fa8;
+      --accent: #7c83ff;
+      --accent-hover: #9da3ff;
+      --green: #66d9a0;
+      --red: #ff6b81;
+    }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      min-height: 100vh;
+    }
+
+    /* Header */
+    .header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 24px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+    }
+
+    .header h1 {
+      font-size: 16px;
+      font-weight: 600;
+      color: var(--accent);
+    }
+
+    .header-actions {
+      display: flex;
+      gap: 8px;
+    }
+
+    /* Buttons */
+    button {
+      font-family: inherit;
+      font-size: 13px;
+      padding: 6px 14px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--surface2);
+      color: var(--text);
+      cursor: pointer;
+      transition: all 0.15s;
+    }
+
+    button:hover { border-color: var(--accent); color: var(--accent); }
+
+    button.primary {
+      background: var(--accent);
+      border-color: var(--accent);
+      color: #fff;
+    }
+
+    button.primary:hover { background: var(--accent-hover); border-color: var(--accent-hover); }
+
+    /* Metadata bar */
+    .metadata {
+      display: flex;
+      gap: 16px;
+      padding: 12px 24px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      flex-wrap: wrap;
+    }
+
+    .field {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+      flex: 1;
+      min-width: 150px;
+    }
+
+    .field label {
+      font-size: 11px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--text-muted);
+    }
+
+    .field input, .field select {
+      font-family: inherit;
+      font-size: 13px;
+      padding: 6px 10px;
+      border-radius: 6px;
+      border: 1px solid var(--border);
+      background: var(--bg);
+      color: var(--text);
+      outline: none;
+    }
+
+    .field input:focus, .field select:focus {
+      border-color: var(--accent);
+    }
+
+    /* Main layout */
+    .main {
+      display: flex;
+      height: calc(100vh - 105px);
+    }
+
+    /* Editor pane */
+    .editor-pane, .preview-pane {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+
+    .editor-pane {
+      border-right: 1px solid var(--border);
+    }
+
+    .pane-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 8px 16px;
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      font-size: 12px;
+      font-weight: 600;
+      text-transform: uppercase;
+      letter-spacing: 0.5px;
+      color: var(--text-muted);
+    }
+
+    .toolbar {
+      display: flex;
+      gap: 2px;
+    }
+
+    .toolbar button {
+      padding: 4px 8px;
+      font-size: 13px;
+      border: none;
+      background: transparent;
+      color: var(--text-muted);
+      border-radius: 4px;
+    }
+
+    .toolbar button:hover {
+      background: var(--surface2);
+      color: var(--text);
+    }
+
+    /* Editor textarea */
+    #editor {
+      flex: 1;
+      width: 100%;
+      padding: 20px 24px;
+      font-family: 'SF Mono', 'Fira Code', 'Cascadia Code', monospace;
+      font-size: 14px;
+      line-height: 1.7;
+      background: var(--bg);
+      color: var(--text);
+      border: none;
+      outline: none;
+      resize: none;
+      tab-size: 2;
+    }
+
+    /* Preview */
+    .preview-content {
+      flex: 1;
+      overflow-y: auto;
+      padding: 24px 32px;
+      background: #fff;
+      color: #1a1a2e;
+    }
+
+    .preview-content h1 { font-size: 2em; margin: 0.5em 0 0.3em; color: #1a1a2e; border-bottom: 1px solid #eee; padding-bottom: 0.3em; }
+    .preview-content h2 { font-size: 1.5em; margin: 1em 0 0.3em; color: #2d2d44; }
+    .preview-content h3 { font-size: 1.2em; margin: 1em 0 0.3em; color: #3d3d54; }
+    .preview-content p { margin: 0.6em 0; line-height: 1.7; }
+    .preview-content a { color: #5b63ff; text-decoration: none; }
+    .preview-content a:hover { text-decoration: underline; }
+    .preview-content code {
+      font-family: 'SF Mono', 'Fira Code', monospace;
+      background: #f0f0f5;
+      padding: 2px 6px;
+      border-radius: 4px;
+      font-size: 0.9em;
+    }
+    .preview-content pre {
+      background: #1a1d2e;
+      color: #e2e4f0;
+      padding: 16px;
+      border-radius: 8px;
+      overflow-x: auto;
+      margin: 1em 0;
+    }
+    .preview-content pre code {
+      background: none;
+      padding: 0;
+      color: inherit;
+    }
+    .preview-content blockquote {
+      border-left: 4px solid #5b63ff;
+      padding: 8px 16px;
+      margin: 1em 0;
+      background: #f5f5ff;
+      color: #444;
+    }
+    .preview-content ul, .preview-content ol { padding-left: 1.5em; margin: 0.6em 0; }
+    .preview-content li { margin: 0.3em 0; line-height: 1.6; }
+    .preview-content img { max-width: 100%; border-radius: 8px; margin: 1em 0; }
+    .preview-content hr { border: none; border-top: 1px solid #e0e0e0; margin: 1.5em 0; }
+    .preview-content table { border-collapse: collapse; width: 100%; margin: 1em 0; }
+    .preview-content th, .preview-content td { border: 1px solid #ddd; padding: 8px 12px; text-align: left; }
+    .preview-content th { background: #f5f5f5; font-weight: 600; }
+
+    /* Status bar */
+    .status-bar {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 4px 16px;
+      background: var(--surface);
+      border-top: 1px solid var(--border);
+      font-size: 11px;
+      color: var(--text-muted);
+    }
+
+    /* Modal */
+    .modal-overlay {
+      display: none;
+      position: fixed;
+      inset: 0;
+      background: rgba(0,0,0,0.6);
+      z-index: 100;
+      align-items: center;
+      justify-content: center;
+    }
+
+    .modal-overlay.active { display: flex; }
+
+    .modal {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: 12px;
+      padding: 24px;
+      width: 90%;
+      max-width: 700px;
+      max-height: 80vh;
+      overflow-y: auto;
+    }
+
+    .modal h2 { font-size: 16px; margin-bottom: 16px; }
+
+    .modal pre {
+      background: var(--bg);
+      padding: 16px;
+      border-radius: 8px;
+      font-size: 12px;
+      line-height: 1.5;
+      overflow-x: auto;
+      white-space: pre-wrap;
+      word-break: break-all;
+    }
+
+    .modal-actions {
+      display: flex;
+      gap: 8px;
+      margin-top: 16px;
+      justify-content: flex-end;
+    }
+
+    /* Toast */
+    .toast {
+      position: fixed;
+      bottom: 40px;
+      right: 24px;
+      background: var(--green);
+      color: #000;
+      padding: 10px 20px;
+      border-radius: 8px;
+      font-size: 13px;
+      font-weight: 500;
+      transform: translateY(80px);
+      opacity: 0;
+      transition: all 0.3s;
+      z-index: 200;
+    }
+
+    .toast.show { transform: translateY(0); opacity: 1; }
+
+    /* Saved posts sidebar */
+    .saved-drawer {
+      display: none;
+      position: fixed;
+      top: 0; right: 0;
+      width: 320px;
+      height: 100%;
+      background: var(--surface);
+      border-left: 1px solid var(--border);
+      z-index: 50;
+      flex-direction: column;
+    }
+
+    .saved-drawer.open { display: flex; }
+
+    .saved-drawer .drawer-header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 12px 16px;
+      border-bottom: 1px solid var(--border);
+    }
+
+    .saved-drawer .drawer-header h2 { font-size: 14px; }
+
+    .saved-list {
+      flex: 1;
+      overflow-y: auto;
+      padding: 8px;
+    }
+
+    .saved-item {
+      padding: 10px 12px;
+      border-radius: 6px;
+      cursor: pointer;
+      margin-bottom: 4px;
+      transition: background 0.15s;
+    }
+
+    .saved-item:hover { background: var(--surface2); }
+
+    .saved-item .title {
+      font-size: 13px;
+      font-weight: 500;
+      margin-bottom: 2px;
+    }
+
+    .saved-item .meta {
+      font-size: 11px;
+      color: var(--text-muted);
+    }
+
+    .saved-item .actions {
+      display: flex;
+      gap: 4px;
+      margin-top: 6px;
+    }
+
+    .saved-item .actions button {
+      font-size: 11px;
+      padding: 2px 8px;
+    }
+
+    .delete-btn:hover { color: var(--red) !important; border-color: var(--red) !important; }
+  </style>
+</head>
+<body>
+
+  <div class="header">
+    <h1>Blog Post Editor</h1>
+    <div class="header-actions">
+      <button onclick="toggleSaved()">Saved Posts</button>
+      <button onclick="newPost()">New Post</button>
+      <button onclick="savePost()">Save Draft</button>
+      <button onclick="exportMarkdown()">Export .md</button>
+      <button class="primary" onclick="exportHTML()">Export HTML</button>
+    </div>
+  </div>
+
+  <div class="metadata">
+    <div class="field" style="flex: 2;">
+      <label>Title</label>
+      <input type="text" id="post-title" placeholder="My Blog Post" oninput="updatePreview()">
+    </div>
+    <div class="field">
+      <label>Date</label>
+      <input type="date" id="post-date">
+    </div>
+    <div class="field">
+      <label>Author</label>
+      <input type="text" id="post-author" placeholder="Author name">
+    </div>
+    <div class="field">
+      <label>Tags</label>
+      <input type="text" id="post-tags" placeholder="tag1, tag2, tag3">
+    </div>
+  </div>
+
+  <div class="main">
+    <div class="editor-pane">
+      <div class="pane-header">
+        <span>Markdown</span>
+        <div class="toolbar">
+          <button onclick="insertMarkdown('**', '**')" title="Bold"><b>B</b></button>
+          <button onclick="insertMarkdown('*', '*')" title="Italic"><i>I</i></button>
+          <button onclick="insertMarkdown('`', '`')" title="Inline code">Code</button>
+          <button onclick="insertMarkdown('\n```\n', '\n```\n')" title="Code block">Block</button>
+          <button onclick="insertMarkdown('[', '](url)')" title="Link">Link</button>
+          <button onclick="insertMarkdown('![alt](', ')')" title="Image">Img</button>
+          <button onclick="insertPrefix('## ')" title="Heading">H2</button>
+          <button onclick="insertPrefix('### ')" title="Heading">H3</button>
+          <button onclick="insertPrefix('- ')" title="List item">List</button>
+          <button onclick="insertPrefix('> ')" title="Blockquote">Quote</button>
+          <button onclick="insertMarkdown('\n---\n', '')" title="Horizontal rule">HR</button>
+        </div>
+      </div>
+      <textarea id="editor" spellcheck="true" placeholder="Write your blog post in Markdown...
+
+# Welcome
+
+Start typing your content here. The preview will update in real-time.
+
+## Formatting
+
+- **Bold** text
+- *Italic* text
+- `inline code`
+- [Links](https://example.com)
+
+```
+code blocks
+```
+" oninput="updatePreview()"></textarea>
+    </div>
+
+    <div class="preview-pane">
+      <div class="pane-header">
+        <span>Preview</span>
+      </div>
+      <div class="preview-content" id="preview"></div>
+    </div>
+  </div>
+
+  <div class="status-bar">
+    <span id="word-count">0 words</span>
+    <span id="char-count">0 characters</span>
+  </div>
+
+  <!-- Export HTML Modal -->
+  <div class="modal-overlay" id="html-modal">
+    <div class="modal">
+      <h2>Exported HTML</h2>
+      <pre id="html-output"></pre>
+      <div class="modal-actions">
+        <button onclick="closeModal('html-modal')">Close</button>
+        <button class="primary" onclick="copyHTML()">Copy to Clipboard</button>
+        <button class="primary" onclick="downloadHTML()">Download .html</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Saved Posts Drawer -->
+  <div class="saved-drawer" id="saved-drawer">
+    <div class="drawer-header">
+      <h2>Saved Drafts</h2>
+      <button onclick="toggleSaved()">Close</button>
+    </div>
+    <div class="saved-list" id="saved-list"></div>
+  </div>
+
+  <div class="toast" id="toast"></div>
+
+  <script>
+    // --- Markdown Parser ---
+    function parseMarkdown(md) {
+      let html = md;
+
+      // Escape HTML (but preserve our markdown)
+      html = html.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+      // Code blocks (fenced)
+      html = html.replace(/```(\w*)\n([\s\S]*?)```/g, function(_, lang, code) {
+        return '<pre><code class="language-' + lang + '">' + code.trim() + '</code></pre>';
+      });
+
+      // Inline code
+      html = html.replace(/`([^`]+)`/g, '<code>$1</code>');
+
+      // Images (before links)
+      html = html.replace(/!\[([^\]]*)\]\(([^)]+)\)/g, '<img src="$2" alt="$1">');
+
+      // Links
+      html = html.replace(/\[([^\]]+)\]\(([^)]+)\)/g, '<a href="$2">$1</a>');
+
+      // Headings
+      html = html.replace(/^#### (.+)$/gm, '<h4>$1</h4>');
+      html = html.replace(/^### (.+)$/gm, '<h3>$1</h3>');
+      html = html.replace(/^## (.+)$/gm, '<h2>$1</h2>');
+      html = html.replace(/^# (.+)$/gm, '<h1>$1</h1>');
+
+      // Blockquotes
+      html = html.replace(/^&gt; (.+)$/gm, '<blockquote><p>$1</p></blockquote>');
+
+      // Horizontal rules
+      html = html.replace(/^---$/gm, '<hr>');
+
+      // Bold and italic
+      html = html.replace(/\*\*\*(.+?)\*\*\*/g, '<strong><em>$1</em></strong>');
+      html = html.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+      html = html.replace(/\*(.+?)\*/g, '<em>$1</em>');
+
+      // Strikethrough
+      html = html.replace(/~~(.+?)~~/g, '<del>$1</del>');
+
+      // Tables
+      html = html.replace(/^(\|.+\|)\n(\|[-| :]+\|)\n((?:\|.+\|\n?)*)/gm, function(_, header, sep, body) {
+        const ths = header.split('|').filter(c => c.trim()).map(c => '<th>' + c.trim() + '</th>').join('');
+        const rows = body.trim().split('\n').map(row => {
+          const tds = row.split('|').filter(c => c.trim()).map(c => '<td>' + c.trim() + '</td>').join('');
+          return '<tr>' + tds + '</tr>';
+        }).join('');
+        return '<table><thead><tr>' + ths + '</tr></thead><tbody>' + rows + '</tbody></table>';
+      });
+
+      // Unordered lists
+      html = html.replace(/^(?:- (.+)\n?)+/gm, function(match) {
+        const items = match.trim().split('\n').map(line => '<li>' + line.replace(/^- /, '') + '</li>').join('');
+        return '<ul>' + items + '</ul>';
+      });
+
+      // Ordered lists
+      html = html.replace(/^(?:\d+\. (.+)\n?)+/gm, function(match) {
+        const items = match.trim().split('\n').map(line => '<li>' + line.replace(/^\d+\. /, '') + '</li>').join('');
+        return '<ol>' + items + '</ol>';
+      });
+
+      // Paragraphs - wrap remaining text blocks
+      html = html.replace(/^(?!<[a-z]|$)(.+)$/gm, '<p>$1</p>');
+
+      // Clean up empty paragraphs
+      html = html.replace(/<p>\s*<\/p>/g, '');
+
+      return html;
+    }
+
+    // --- Editor Functions ---
+    const editor = document.getElementById('editor');
+    const preview = document.getElementById('preview');
+
+    function updatePreview() {
+      const title = document.getElementById('post-title').value;
+      const md = editor.value;
+      let html = '';
+
+      if (title) {
+        html += '<h1>' + escapeHtml(title) + '</h1>';
+      }
+
+      html += parseMarkdown(md);
+      preview.innerHTML = html;
+
+      // Word and char count
+      const text = md.trim();
+      const words = text ? text.split(/\s+/).length : 0;
+      document.getElementById('word-count').textContent = words + ' word' + (words !== 1 ? 's' : '');
+      document.getElementById('char-count').textContent = text.length + ' character' + (text.length !== 1 ? 's' : '');
+    }
+
+    function escapeHtml(text) {
+      const div = document.createElement('div');
+      div.textContent = text;
+      return div.innerHTML;
+    }
+
+    function insertMarkdown(before, after) {
+      const start = editor.selectionStart;
+      const end = editor.selectionEnd;
+      const selected = editor.value.substring(start, end);
+      const replacement = before + (selected || 'text') + after;
+      editor.setRangeText(replacement, start, end, 'select');
+      editor.focus();
+      updatePreview();
+    }
+
+    function insertPrefix(prefix) {
+      const start = editor.selectionStart;
+      const lineStart = editor.value.lastIndexOf('\n', start - 1) + 1;
+      editor.setRangeText(prefix, lineStart, lineStart, 'end');
+      editor.focus();
+      updatePreview();
+    }
+
+    // Tab key support
+    editor.addEventListener('keydown', function(e) {
+      if (e.key === 'Tab') {
+        e.preventDefault();
+        const start = this.selectionStart;
+        this.setRangeText('  ', start, start, 'end');
+        updatePreview();
+      }
+    });
+
+    // --- Save / Load ---
+    function getPostData() {
+      return {
+        title: document.getElementById('post-title').value,
+        date: document.getElementById('post-date').value,
+        author: document.getElementById('post-author').value,
+        tags: document.getElementById('post-tags').value,
+        content: editor.value,
+        savedAt: new Date().toISOString()
+      };
+    }
+
+    function loadPostData(data) {
+      document.getElementById('post-title').value = data.title || '';
+      document.getElementById('post-date').value = data.date || '';
+      document.getElementById('post-author').value = data.author || '';
+      document.getElementById('post-tags').value = data.tags || '';
+      editor.value = data.content || '';
+      updatePreview();
+    }
+
+    function savePost() {
+      const data = getPostData();
+      if (!data.title) {
+        data.title = 'Untitled Post';
+      }
+      const posts = JSON.parse(localStorage.getItem('blog_posts') || '{}');
+      const key = data.title.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+      posts[key] = data;
+      localStorage.setItem('blog_posts', JSON.stringify(posts));
+      showToast('Draft saved');
+      renderSavedList();
+    }
+
+    function loadPost(key) {
+      const posts = JSON.parse(localStorage.getItem('blog_posts') || '{}');
+      if (posts[key]) {
+        loadPostData(posts[key]);
+        toggleSaved();
+        showToast('Post loaded');
+      }
+    }
+
+    function deletePost(key, e) {
+      e.stopPropagation();
+      const posts = JSON.parse(localStorage.getItem('blog_posts') || '{}');
+      delete posts[key];
+      localStorage.setItem('blog_posts', JSON.stringify(posts));
+      renderSavedList();
+      showToast('Draft deleted');
+    }
+
+    function newPost() {
+      loadPostData({ title: '', date: new Date().toISOString().split('T')[0], author: '', tags: '', content: '' });
+    }
+
+    // --- Saved posts drawer ---
+    function toggleSaved() {
+      const drawer = document.getElementById('saved-drawer');
+      drawer.classList.toggle('open');
+      if (drawer.classList.contains('open')) {
+        renderSavedList();
+      }
+    }
+
+    function renderSavedList() {
+      const posts = JSON.parse(localStorage.getItem('blog_posts') || '{}');
+      const list = document.getElementById('saved-list');
+      const keys = Object.keys(posts);
+
+      if (keys.length === 0) {
+        list.innerHTML = '<div style="padding: 16px; color: var(--text-muted); font-size: 13px;">No saved drafts yet.</div>';
+        return;
+      }
+
+      list.innerHTML = keys.map(key => {
+        const p = posts[key];
+        const date = p.savedAt ? new Date(p.savedAt).toLocaleDateString() : '';
+        return '<div class="saved-item" onclick="loadPost(\'' + key + '\')">'
+          + '<div class="title">' + escapeHtml(p.title || 'Untitled') + '</div>'
+          + '<div class="meta">' + date + (p.tags ? ' &middot; ' + escapeHtml(p.tags) : '') + '</div>'
+          + '<div class="actions"><button class="delete-btn" onclick="deletePost(\'' + key + '\', event)">Delete</button></div>'
+          + '</div>';
+      }).join('');
+    }
+
+    // --- Export ---
+    function generateFrontMatter() {
+      const title = document.getElementById('post-title').value;
+      const date = document.getElementById('post-date').value;
+      const author = document.getElementById('post-author').value;
+      const tags = document.getElementById('post-tags').value;
+
+      let fm = '---\n';
+      if (title) fm += 'title: "' + title + '"\n';
+      if (date) fm += 'date: ' + date + '\n';
+      if (author) fm += 'author: "' + author + '"\n';
+      if (tags) fm += 'tags: [' + tags.split(',').map(t => '"' + t.trim() + '"').join(', ') + ']\n';
+      fm += '---\n\n';
+      return fm;
+    }
+
+    function exportMarkdown() {
+      const content = generateFrontMatter() + editor.value;
+      downloadFile(content, getFilename('.md'), 'text/markdown');
+      showToast('Markdown exported');
+    }
+
+    function exportHTML() {
+      const title = document.getElementById('post-title').value || 'Blog Post';
+      const date = document.getElementById('post-date').value;
+      const author = document.getElementById('post-author').value;
+      const content = parseMarkdown(editor.value);
+
+      const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${escapeHtml(title)}</title>
+  <style>
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      max-width: 720px;
+      margin: 0 auto;
+      padding: 40px 20px;
+      color: #1a1a2e;
+      line-height: 1.7;
+    }
+    h1 { font-size: 2em; margin-bottom: 0.3em; }
+    h2 { font-size: 1.5em; margin-top: 1.5em; }
+    h3 { font-size: 1.2em; margin-top: 1.2em; }
+    .post-meta { color: #666; font-size: 0.9em; margin-bottom: 2em; }
+    a { color: #5b63ff; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    code { background: #f0f0f5; padding: 2px 6px; border-radius: 4px; font-size: 0.9em; }
+    pre { background: #1a1d2e; color: #e2e4f0; padding: 16px; border-radius: 8px; overflow-x: auto; }
+    pre code { background: none; padding: 0; color: inherit; }
+    blockquote { border-left: 4px solid #5b63ff; padding: 8px 16px; margin: 1em 0; background: #f5f5ff; }
+    img { max-width: 100%; border-radius: 8px; }
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ddd; padding: 8px 12px; text-align: left; }
+    th { background: #f5f5f5; }
+    hr { border: none; border-top: 1px solid #e0e0e0; margin: 2em 0; }
+  </style>
+</head>
+<body>
+  <article>
+    <h1>${escapeHtml(title)}</h1>
+    <div class="post-meta">${date ? escapeHtml(date) : ''}${author ? ' &middot; ' + escapeHtml(author) : ''}</div>
+    ${content}
+  </article>
+</body>
+</html>`;
+
+      document.getElementById('html-output').textContent = html;
+      document.getElementById('html-modal').classList.add('active');
+    }
+
+    function copyHTML() {
+      const text = document.getElementById('html-output').textContent;
+      navigator.clipboard.writeText(text).then(() => showToast('Copied to clipboard'));
+    }
+
+    function downloadHTML() {
+      const text = document.getElementById('html-output').textContent;
+      downloadFile(text, getFilename('.html'), 'text/html');
+      closeModal('html-modal');
+      showToast('HTML downloaded');
+    }
+
+    function closeModal(id) {
+      document.getElementById(id).classList.remove('active');
+    }
+
+    // Click outside modal to close
+    document.querySelectorAll('.modal-overlay').forEach(overlay => {
+      overlay.addEventListener('click', function(e) {
+        if (e.target === this) this.classList.remove('active');
+      });
+    });
+
+    // --- Helpers ---
+    function getFilename(ext) {
+      const title = document.getElementById('post-title').value || 'post';
+      const date = document.getElementById('post-date').value || new Date().toISOString().split('T')[0];
+      const slug = title.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+      return date + '-' + slug + ext;
+    }
+
+    function downloadFile(content, filename, mimeType) {
+      const blob = new Blob([content], { type: mimeType });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(url);
+    }
+
+    function showToast(msg) {
+      const toast = document.getElementById('toast');
+      toast.textContent = msg;
+      toast.classList.add('show');
+      setTimeout(() => toast.classList.remove('show'), 2000);
+    }
+
+    // --- Init ---
+    document.getElementById('post-date').value = new Date().toISOString().split('T')[0];
+    updatePreview();
+  </script>
+</body>
+</html>

--- a/index.md
+++ b/index.md
@@ -1,0 +1,22 @@
+---
+layout: home
+title: "Sylvain Bauza"
+---
+
+Welcome! I'm Sylvain Bauza, a software engineer working on OpenStack and cloud computing.
+
+## Projects
+
+- [OpenStack Agentic Workloads](openstack-agentic-workloads/) — Running AI agent workloads on OpenStack infrastructure
+- [Ambient Code](ambient-code/) — Claude Code agents and skills for OpenStack Nova
+
+## Presentations
+
+- [OpenStack 101](2014/07/01/openstack_101.html) — Introduction to OpenStack
+- [Juno Roadmap](2014/07/01/juno_roadmap.html) — OpenStack Juno release roadmap
+- [Docker, What Else?](2015/03/19/docker_what_else.html) — Docker overview
+- [vGPU Live Migration](vgpu/vgpu_live_migration.html) — GPU virtualization demo
+
+## Resources
+
+- [AGENTS.md for OpenStack Nova](agentready/) — AgentReady assessment reports

--- a/openstack-agentic-workloads/getting-started.md
+++ b/openstack-agentic-workloads/getting-started.md
@@ -1,0 +1,80 @@
+---
+layout: page
+title: "Getting Started"
+---
+
+This guide walks you through setting up OpenStack for running agentic AI workloads.
+
+## Prerequisites
+
+- An OpenStack deployment with Nova, Placement, Neutron, and Glance services
+- At least one compute node with GPU resources (for vGPU workloads)
+- Admin access to create flavors and manage resources
+
+## Step 1: Configure GPU Resources
+
+Register vGPU resources in Placement so Nova can schedule GPU workloads:
+
+```bash
+# Verify GPU inventory on compute nodes
+openstack resource provider inventory list <compute-node-uuid>
+
+# Check available vGPU resource classes
+openstack resource class list | grep VGPU
+```
+
+## Step 2: Create an Agent Flavor
+
+Create a Nova flavor tailored for AI agent workloads:
+
+```bash
+openstack flavor create agent-gpu \
+  --vcpus 4 --ram 8192 --disk 40 \
+  --property resources:VGPU=1
+```
+
+For CPU-only agents:
+
+```bash
+openstack flavor create agent-cpu \
+  --vcpus 2 --ram 4096 --disk 20
+```
+
+## Step 3: Prepare an Agent Image
+
+Upload a base image with your agent runtime pre-installed:
+
+```bash
+openstack image create agent-base \
+  --file ubuntu-agent.qcow2 \
+  --disk-format qcow2 \
+  --container-format bare
+```
+
+## Step 4: Launch an Agent Instance
+
+```bash
+openstack server create my-agent \
+  --flavor agent-gpu \
+  --image agent-base \
+  --network agent-net \
+  --key-name my-key
+```
+
+## Step 5: Verify
+
+```bash
+# Check instance status
+openstack server show my-agent -f value -c status
+
+# Get console access
+openstack console url show my-agent
+```
+
+## Next Steps
+
+- Configure auto-scaling for agent workloads
+- Set up monitoring and logging
+- Explore [live migration](../vgpu/vgpu_live_migration.html) for GPU workloads
+
+Back to [OpenStack Agentic Workloads](./)

--- a/openstack-agentic-workloads/index.md
+++ b/openstack-agentic-workloads/index.md
@@ -1,0 +1,66 @@
+---
+layout: page
+title: "OpenStack Agentic Workloads"
+---
+
+This project explores running AI agent workloads on OpenStack infrastructure, leveraging Nova's compute capabilities to provision and manage virtual machines for autonomous AI agents.
+
+## Overview
+
+Agentic workloads are AI-driven processes that autonomously execute tasks, make decisions, and interact with their environment. OpenStack provides the ideal infrastructure layer for running these workloads at scale.
+
+### Key Capabilities
+
+- **VM provisioning** for isolated agent environments
+- **GPU passthrough** via vGPU for accelerated inference
+- **Dynamic scaling** based on workload demand
+- **Network isolation** between agent instances
+
+## Architecture
+
+```
+┌──────────────┐     ┌──────────────┐     ┌──────────────┐
+│  Agent API   │────▶│  Nova        │────▶│  Compute     │
+│  (Orchestr.) │     │  (Scheduler) │     │  (Hypervisor)│
+└──────────────┘     └──────────────┘     └──────────────┘
+       │                                         │
+       ▼                                         ▼
+┌──────────────┐                          ┌──────────────┐
+│  Placement   │                          │  Agent VM    │
+│  (Resources) │                          │  (Workload)  │
+└──────────────┘                          └──────────────┘
+```
+
+## Quick Start
+
+1. Deploy an OpenStack cloud with Nova and Placement services
+2. Configure a flavor with GPU resources for agent workloads:
+   ```bash
+   openstack flavor create agent-gpu \
+     --vcpus 4 --ram 8192 --disk 40 \
+     --property resources:VGPU=1
+   ```
+3. Launch an agent instance:
+   ```bash
+   openstack server create my-agent \
+     --flavor agent-gpu \
+     --image ubuntu-22.04 \
+     --network agent-net
+   ```
+
+## How It Works
+
+The system uses Nova's scheduling and placement services to match agent workload requirements with available compute resources:
+
+- **Placement API** tracks GPU inventory across compute nodes
+- **Nova Scheduler** selects the best host based on resource availability
+- **Live migration** enables workload rebalancing without agent downtime
+
+## Pages
+
+- [Getting Started](getting-started) — Setup guide for running agent workloads on OpenStack
+
+## Related Resources
+
+- [Nova AGENTS.md](../agentready/) — AgentReady assessment for OpenStack Nova
+- [vGPU Live Migration Demo](../vgpu/vgpu_live_migration.html) — GPU virtualization in action


### PR DESCRIPTION
## Summary
- Adds a self-contained blog post editor at `/editor/` on the GitHub Pages site
- Features: Markdown editing with formatting toolbar, live side-by-side preview, metadata fields (title, date, author, tags), draft saving via localStorage, and export to both Markdown (with YAML front matter) and standalone HTML
- No external dependencies — single HTML file with inline CSS and JS

## Test plan
- [ ] Open `https://sbauza.github.io/editor/` after merge and verify the editor loads
- [ ] Type markdown content and confirm live preview renders correctly
- [ ] Test toolbar buttons (bold, italic, code, headings, etc.)
- [ ] Save a draft and reload the page to confirm persistence
- [ ] Export as Markdown and HTML, verify output files

🤖 Generated with [Claude Code](https://claude.com/claude-code)