### PR TITLE
Add LinkedIn and X social links

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -22,6 +22,12 @@ author:
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
       url: "https://github.com/sbauza"
+    - label: "LinkedIn"
+      icon: "fab fa-fw fa-linkedin"
+      url: "https://www.linkedin.com/in/sylvainbauza/"
+    - label: "X"
+      icon: "fab fa-fw fa-square-x-twitter"
+      url: "https://x.com/sylvainbauza"
 
 # Site Footer
 footer:
@@ -29,6 +35,12 @@ footer:
     - label: "GitHub"
       icon: "fab fa-fw fa-github"
       url: "https://github.com/sbauza"
+    - label: "LinkedIn"
+      icon: "fab fa-fw fa-linkedin"
+      url: "https://www.linkedin.com/in/sylvainbauza/"
+    - label: "X"
+      icon: "fab fa-fw fa-square-x-twitter"
+      url: "https://x.com/sylvainbauza"
 
 # Reading Files
 include:


### PR DESCRIPTION
## Summary
- Add LinkedIn badge below GitHub in the author sidebar
- Add X (Twitter) badge below LinkedIn in the author sidebar
- Mirror both links in the site footer

## Test plan
- [ ] Verify LinkedIn icon appears in sidebar below GitHub
- [ ] Verify X icon appears in sidebar below LinkedIn
- [ ] Confirm both links open the correct profiles
- [ ] Check footer also shows all three social links

🤖 Generated with [Claude Code](https://claude.com/claude-code)