### PR TITLE
Move vGPU presentation from posts to page

### DIFF
--- a/_pages/vgpu-openinfra-day-france.md
+++ b/_pages/vgpu-openinfra-day-france.md
@@ -1,14 +1,8 @@
 ---
 layout: single
 title: "How can I give virtual GPU resources to my end users seamlessly?"
-date: 2024-05-22
-categories:
-  - Presentations
-tags:
-  - openstack
-  - nova
-  - vgpu
-  - gpu
+permalink: /presentations/vgpu-openinfra-day-france/
+author_profile: true
 ---
 
 Presentation given at **OpenInfra Day France 2024** about virtual GPU support in OpenStack Nova — covering VFIO-mdev, SR-IOV GPUs, vGPU live migration, and unified limits.


### PR DESCRIPTION
## Summary
- Move vGPU presentation from `_posts/` to `_pages/` so it doesn't appear on the homepage
- Accessible only via the Presentations nav link

## Test plan
- [ ] Verify presentation no longer appears on homepage
- [ ] Confirm it's accessible at `/presentations/vgpu-openinfra-day-france/`
- [ ] Check Presentations page link still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)