### PR TITLE
Add three OpenInfra Summit presentations

### DIFF
--- a/_pages/bug-triage-2018.md
+++ b/_pages/bug-triage-2018.md
@@ -1,0 +1,16 @@
+---
+layout: single
+title: "Upstream bug triage: The hidden gem?"
+permalink: /presentations/bug-triage-2018/
+author_profile: true
+---
+
+Presentation given at the **OpenInfra Summit, November 2018** about upstream bug triage processes in OpenStack.
+
+## Video
+
+<iframe width="100%" height="400" src="https://www.youtube.com/embed/zBHZIRpJDYA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+## Slides
+
+<iframe src="https://docs.google.com/presentation/d/1s1B4Cym5OeiVR0We0bgwYKIDYCZIrtYk6ENAm6esLZ4/embed?start=false&loop=false&delayms=3000" frameborder="0" width="100%" height="450" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>

--- a/_pages/gpus-split-cake-2020.md
+++ b/_pages/gpus-split-cake-2020.md
@@ -1,0 +1,16 @@
+---
+layout: single
+title: "How to split a cake? GPUs with OpenStack"
+permalink: /presentations/gpus-split-cake-2020/
+author_profile: true
+---
+
+Presentation given at the **OpenInfra Summit, October 2020** about sharing GPU resources across tenants in OpenStack using virtual GPUs.
+
+## Video
+
+<iframe width="100%" height="400" src="https://www.youtube.com/embed/sQCgyo2BRe4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+## Slides
+
+<iframe src="https://docs.google.com/presentation/d/1zPrPDWScXZhukDrJR2dqcVEgRVQPMX95ObRNTX0Vl_s/embed?start=false&loop=false&delayms=3000" frameborder="0" width="100%" height="450" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>

--- a/_pages/presentations.md
+++ b/_pages/presentations.md
@@ -6,6 +6,9 @@ author_profile: true
 ---
 
 - [How can I give virtual GPU resources to my end users seamlessly?](/presentations/vgpu-openinfra-day-france/) — OpenInfra Day France 2024
+- [How to split a cake? GPUs with OpenStack](/presentations/gpus-split-cake-2020/) — OpenInfra Summit, October 2020
+- [Call it real Virtual GPUs in Nova](/presentations/virtual-gpus-nova-2019/) — OpenInfra Summit, May 2019
+- [Upstream bug triage: The hidden gem?](/presentations/bug-triage-2018/) — OpenInfra Summit, November 2018
 - [OpenStack 101](/2014/07/01/openstack_101.html) — Introduction to OpenStack
 - [Juno Roadmap](/2014/07/01/juno_roadmap.html) — OpenStack Juno release roadmap
 - [Docker, What Else?](/2015/03/19/docker_what_else.html) — Docker overview

--- a/_pages/virtual-gpus-nova-2019.md
+++ b/_pages/virtual-gpus-nova-2019.md
@@ -1,0 +1,20 @@
+---
+layout: single
+title: "Call it real Virtual GPUs in Nova"
+permalink: /presentations/virtual-gpus-nova-2019/
+author_profile: true
+---
+
+Presentation given at the **OpenInfra Summit, May 2019** about virtual GPU support in OpenStack Nova.
+
+## Video
+
+<iframe width="100%" height="400" src="https://www.youtube.com/embed/p_HAoTtqCkY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+
+## Slides
+
+<iframe src="https://docs.google.com/presentation/d/1HNXbT1awinXVWVMfB1LqGAALhzYS9HNoRln24zcjNxc/embed?start=false&loop=false&delayms=3000" frameborder="0" width="100%" height="450" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+
+## Screencast
+
+<iframe src="https://drive.google.com/file/d/1MVQXS5OVlpW16ku6sp69nPqhQqN8xHrv/preview" width="100%" height="400" allow="autoplay"></iframe>


### PR DESCRIPTION
## Summary
- Add 3 presentation pages with embedded YouTube videos and Google Slides
  - **Oct 2020**: How to split a cake? GPUs with OpenStack
  - **May 2019**: Call it real Virtual GPUs in Nova (+ Google Drive screencast)
  - **Nov 2018**: Upstream bug triage: The hidden gem?
- Updated Presentations page with links to all three

## Test plan
- [ ] Check each presentation page loads with embedded video and slides
- [ ] Verify YouTube embeds play correctly
- [ ] Verify Google Slides embeds are navigable
- [ ] Check the May 2019 screencast embed works
- [ ] Confirm Presentations page lists all entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)