### PR TITLE
Fix responsive video/slides embeds

### DIFF
--- a/_pages/bug-triage-2018.md
+++ b/_pages/bug-triage-2018.md
@@ -9,8 +9,12 @@ Presentation given at the **OpenInfra Summit, November 2018** about upstream bug
 
 ## Video
 
-<iframe width="100%" height="400" src="https://www.youtube.com/embed/zBHZIRpJDYA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://www.youtube.com/embed/zBHZIRpJDYA" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 
 ## Slides
 
-<iframe src="https://docs.google.com/presentation/d/1s1B4Cym5OeiVR0We0bgwYKIDYCZIrtYk6ENAm6esLZ4/embed?start=false&loop=false&delayms=3000" frameborder="0" width="100%" height="450" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://docs.google.com/presentation/d/1s1B4Cym5OeiVR0We0bgwYKIDYCZIrtYk6ENAm6esLZ4/embed?start=false&loop=false&delayms=3000" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>

--- a/_pages/gpus-split-cake-2020.md
+++ b/_pages/gpus-split-cake-2020.md
@@ -9,8 +9,12 @@ Presentation given at the **OpenInfra Summit, October 2020** about sharing GPU r
 
 ## Video
 
-<iframe width="100%" height="400" src="https://www.youtube.com/embed/sQCgyo2BRe4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://www.youtube.com/embed/sQCgyo2BRe4" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 
 ## Slides
 
-<iframe src="https://docs.google.com/presentation/d/1zPrPDWScXZhukDrJR2dqcVEgRVQPMX95ObRNTX0Vl_s/embed?start=false&loop=false&delayms=3000" frameborder="0" width="100%" height="450" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://docs.google.com/presentation/d/1zPrPDWScXZhukDrJR2dqcVEgRVQPMX95ObRNTX0Vl_s/embed?start=false&loop=false&delayms=3000" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>

--- a/_pages/virtual-gpus-nova-2019.md
+++ b/_pages/virtual-gpus-nova-2019.md
@@ -9,12 +9,18 @@ Presentation given at the **OpenInfra Summit, May 2019** about virtual GPU suppo
 
 ## Video
 
-<iframe width="100%" height="400" src="https://www.youtube.com/embed/p_HAoTtqCkY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://www.youtube.com/embed/p_HAoTtqCkY" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
 
 ## Slides
 
-<iframe src="https://docs.google.com/presentation/d/1HNXbT1awinXVWVMfB1LqGAALhzYS9HNoRln24zcjNxc/embed?start=false&loop=false&delayms=3000" frameborder="0" width="100%" height="450" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://docs.google.com/presentation/d/1HNXbT1awinXVWVMfB1LqGAALhzYS9HNoRln24zcjNxc/embed?start=false&loop=false&delayms=3000" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>
 
 ## Screencast
 
-<iframe src="https://drive.google.com/file/d/1MVQXS5OVlpW16ku6sp69nPqhQqN8xHrv/preview" width="100%" height="400" allow="autoplay"></iframe>
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://drive.google.com/file/d/1MVQXS5OVlpW16ku6sp69nPqhQqN8xHrv/preview" frameborder="0" allow="autoplay"></iframe>
+</div>


### PR DESCRIPTION
## Summary
- Wraps all YouTube, Google Slides, and Google Drive iframes in responsive 16:9 containers (`padding-bottom: 56.25%`)
- Fixes wrong video sizing on the three presentation pages (gpus-split-cake-2020, virtual-gpus-nova-2019, bug-triage-2018)
- Embeds now scale properly at any viewport width instead of using a fixed height

## Test plan
- [ ] Check https://sbauza.github.io/presentations/gpus-split-cake-2020/ — video and slides fill width with 16:9 ratio
- [ ] Check https://sbauza.github.io/presentations/virtual-gpus-nova-2019/ — video, slides, and screencast all responsive
- [ ] Check https://sbauza.github.io/presentations/bug-triage-2018/ — video and slides responsive

🤖 Generated with [Claude Code](https://claude.com/claude-code)