### PR TITLE
Add 4 new presentation pages (2023-2025)

### DIFF
--- a/_pages/nova-contributions-2024.md
+++ b/_pages/nova-contributions-2024.md
@@ -1,0 +1,20 @@
+---
+layout: single
+title: "When you want to help OpenStack Nova but you don't know how to do it"
+permalink: /presentations/nova-contributions-2024/
+author_profile: true
+---
+
+Presentation given at the **OpenInfra Summit Asia 2024** about how to get started contributing to OpenStack Nova.
+
+## Video
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://www.youtube.com/embed/NH2bkhdQ_lI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+## Slides
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://docs.google.com/presentation/d/1zl_n2W3fP6uI8yVNIPRqtFFrMeAvwyX71AXMCjPiaak/embed?start=false&loop=false&delayms=3000" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>

--- a/_pages/nova-contributors-2025.md
+++ b/_pages/nova-contributors-2025.md
@@ -1,0 +1,20 @@
+---
+layout: single
+title: "We can all be Nova contributors"
+permalink: /presentations/nova-contributors-2025/
+author_profile: true
+---
+
+Presentation given at the **OpenInfra Summit Europe 2025** about how everyone can contribute to OpenStack Nova.
+
+## Video
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://www.youtube.com/embed/MbUB4R7SQSM" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+## Slides
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://docs.google.com/presentation/d/1ljz1Np4gf07MGXF2CWEumTbFZBqsdfsYAbGBZFfjqH0/embed?start=false&loop=false&delayms=3000" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>

--- a/_pages/nova-power-management-2023.md
+++ b/_pages/nova-power-management-2023.md
@@ -1,0 +1,34 @@
+---
+layout: single
+title: "What's new in Nova power management and sustainability"
+permalink: /presentations/nova-power-management-2023/
+author_profile: true
+---
+
+Presentation given at the **OpenInfra Summit Berlin, June 2023** about power management and sustainability features in OpenStack Nova.
+
+## Video
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://www.youtube.com/embed/6Sv-xuOSKMI" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+## Slides
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://docs.google.com/presentation/d/1OVRRfMSz0yuU25GuDFIfW5HAXzDCrTx8xscW4OR8AXc/embed?start=false&loop=false&delayms=3000" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>
+
+## Screencasts
+
+### Part 1
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://drive.google.com/file/d/1IoNMt_t3NcxQEqZS1BMY7dwLYPSdheB-/preview" frameborder="0" allow="autoplay"></iframe>
+</div>
+
+### Part 2
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://drive.google.com/file/d/1r9Lz-3Za9JAoq8K2pPRybuZgdAZrWB6q/preview" frameborder="0" allow="autoplay"></iframe>
+</div>

--- a/_pages/nova-power-management-2023.md
+++ b/_pages/nova-power-management-2023.md
@@ -5,7 +5,7 @@ permalink: /presentations/nova-power-management-2023/
 author_profile: true
 ---
 
-Presentation given at the **OpenInfra Summit Berlin, June 2023** about power management and sustainability features in OpenStack Nova.
+Presentation given at the **OpenInfra Summit Vancouver, June 2023** about power management and sustainability features in OpenStack Nova.
 
 ## Video
 

--- a/_pages/presentations.md
+++ b/_pages/presentations.md
@@ -9,7 +9,7 @@ author_profile: true
 - [How can I give virtual GPU resources to my end users seamlessly?](/presentations/vgpu-openinfra-summit-asia-2024/) — OpenInfra Summit Asia 2024
 - [When you want to help OpenStack Nova but you don't know how to do it](/presentations/nova-contributions-2024/) — OpenInfra Summit Asia 2024
 - [How can I give virtual GPU resources to my end users seamlessly?](/presentations/vgpu-openinfra-day-france/) — OpenInfra Day France 2024
-- [What's new in Nova power management and sustainability](/presentations/nova-power-management-2023/) — OpenInfra Summit Berlin 2023
+- [What's new in Nova power management and sustainability](/presentations/nova-power-management-2023/) — OpenInfra Summit Vancouver 2023
 - [How to split a cake? GPUs with OpenStack](/presentations/gpus-split-cake-2020/) — OpenInfra Summit, October 2020
 - [Call it real Virtual GPUs in Nova](/presentations/virtual-gpus-nova-2019/) — OpenInfra Summit, May 2019
 - [Upstream bug triage: The hidden gem?](/presentations/bug-triage-2018/) — OpenInfra Summit, November 2018

--- a/_pages/presentations.md
+++ b/_pages/presentations.md
@@ -5,7 +5,11 @@ permalink: /presentations/
 author_profile: true
 ---
 
+- [We can all be Nova contributors](/presentations/nova-contributors-2025/) — OpenInfra Summit Europe 2025
+- [How can I give virtual GPU resources to my end users seamlessly?](/presentations/vgpu-openinfra-summit-asia-2024/) — OpenInfra Summit Asia 2024
+- [When you want to help OpenStack Nova but you don't know how to do it](/presentations/nova-contributions-2024/) — OpenInfra Summit Asia 2024
 - [How can I give virtual GPU resources to my end users seamlessly?](/presentations/vgpu-openinfra-day-france/) — OpenInfra Day France 2024
+- [What's new in Nova power management and sustainability](/presentations/nova-power-management-2023/) — OpenInfra Summit Berlin 2023
 - [How to split a cake? GPUs with OpenStack](/presentations/gpus-split-cake-2020/) — OpenInfra Summit, October 2020
 - [Call it real Virtual GPUs in Nova](/presentations/virtual-gpus-nova-2019/) — OpenInfra Summit, May 2019
 - [Upstream bug triage: The hidden gem?](/presentations/bug-triage-2018/) — OpenInfra Summit, November 2018

--- a/_pages/vgpu-openinfra-summit-asia-2024.md
+++ b/_pages/vgpu-openinfra-summit-asia-2024.md
@@ -1,0 +1,20 @@
+---
+layout: single
+title: "How can I give virtual GPU resources to my end users seamlessly?"
+permalink: /presentations/vgpu-openinfra-summit-asia-2024/
+author_profile: true
+---
+
+Presentation given at the **OpenInfra Summit Asia 2024** about virtual GPU support in OpenStack Nova.
+
+## Video
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://www.youtube.com/embed/MJKPv5tKu-c" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe>
+</div>
+
+## Slides
+
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;">
+  <iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://docs.google.com/presentation/d/1S_shLL4grvLXLxzLvK7HlGeJ6QcNur2s-M8SjWJfuC4/embed?start=false&loop=false&delayms=3000" frameborder="0" allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true"></iframe>
+</div>


### PR DESCRIPTION
## Summary
- **Nova power management and sustainability** — OpenInfra Summit Berlin 2023 (video + slides + 2 screencasts)
- **How can I give virtual GPU resources to my end users seamlessly?** — OpenInfra Summit Asia 2024 (video + slides)
- **When you want to help OpenStack Nova but you don't know how to do it** — OpenInfra Summit Asia 2024 (video + slides)
- **We can all be Nova contributors** — OpenInfra Summit Europe 2025 (video + slides)
- Updated presentations index page with all 4 new entries in chronological order

All embeds use responsive 16:9 containers.

## Test plan
- [ ] Check /presentations/ index page lists all new entries
- [ ] Check /presentations/nova-power-management-2023/ — video, slides, 2 screencasts
- [ ] Check /presentations/vgpu-openinfra-summit-asia-2024/ — video, slides
- [ ] Check /presentations/nova-contributions-2024/ — video, slides
- [ ] Check /presentations/nova-contributors-2025/ — video, slides

🤖 Generated with [Claude Code](https://claude.com/claude-code)